### PR TITLE
fix: update postcss.config.mjs to use ES module syntax

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,7 +1,9 @@
-// Update the PostCSS config to use CommonJS format
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-}
+/** @type {import('postcss-load-config').Config} */
+const config = {
+plugins: {
+  tailwindcss: {},
+  autoprefixer: {},
+},
+};
+
+export default config;


### PR DESCRIPTION
Correct syntax error in postcss.config.mjs to resolve build issues.

#VERCEL_SKIP